### PR TITLE
Linked most animations to Charger

### DIFF
--- a/Lasso/Assets/Animations/PCAnimations/BruteAnimationController.controller
+++ b/Lasso/Assets/Animations/PCAnimations/BruteAnimationController.controller
@@ -11,16 +11,19 @@ AnimatorStateTransition:
   - m_ConditionMode: 1
     m_ConditionEvent: isRunning
     m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: isWalking
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -6122710525524246578}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.84210527
-  m_HasExitTime: 1
+  m_TransitionDuration: 0.094971895
+  m_TransitionOffset: 0.2906782
+  m_ExitTime: 0.94001794
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -628,9 +631,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.53125
+  m_TransitionDuration: 0.10209039
+  m_TransitionOffset: 0.093416505
+  m_ExitTime: 0.8085805
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -702,79 +705,79 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 1
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: move
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: playerDetected
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: charge
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: lookForPlayerState
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: meleeAttack
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: stun
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: NEW VARIABLES
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 1
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isKilled
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isIdle
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isRunning
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isWalking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isAttacking
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -1161,6 +1164,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &7564643730509514366
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isWalking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8405481338485848312}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.8965517
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &7821580234511038571
 AnimatorState:
   serializedVersion: 6
@@ -1175,6 +1203,7 @@ AnimatorState:
   - {fileID: 1437949507646629063}
   - {fileID: 3932897189870737695}
   - {fileID: 7282966933079776689}
+  - {fileID: 7564643730509514366}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Lasso/Assets/Animations/PCAnimations/BruteIdle_anim.anim
+++ b/Lasso/Assets/Animations/PCAnimations/BruteIdle_anim.anim
@@ -37191,7 +37191,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Lasso/Assets/Levels/EnemyRework.unity
+++ b/Lasso/Assets/Levels/EnemyRework.unity
@@ -2114,6 +2114,32 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 50c6ba5b63e02d0418279e55f7fc6030, type: 3}
+--- !u!1 &1922784065 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5954947448250239329, guid: 385ee5c7b4d45a947a0e40c439f98fed, type: 3}
+  m_PrefabInstance: {fileID: 1112250266437784247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &1922784070
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922784065}
+  m_Enabled: 1
+  m_Avatar: {fileID: 9000000, guid: db83ed7dd99215741a8fe2e68b0245c1, type: 3}
+  m_Controller: {fileID: 9100000, guid: e52760ce48dbd324b8eec05484958d95, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &1967623029 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3415769629978198116, guid: 23c57294e911e0a4cbd473583245a796, type: 3}
@@ -2492,10 +2518,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Charger
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 62482039860509144, guid: 385ee5c7b4d45a947a0e40c439f98fed, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5954947448250239329, guid: 385ee5c7b4d45a947a0e40c439f98fed, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1922784070}
   m_SourcePrefab: {fileID: 100100000, guid: 385ee5c7b4d45a947a0e40c439f98fed, type: 3}
 --- !u!1001 &2099083873264685506
 PrefabInstance:

--- a/Lasso/Assets/Scripts/EnemyControl.cs
+++ b/Lasso/Assets/Scripts/EnemyControl.cs
@@ -180,6 +180,12 @@ public class EnemyControl : MonoBehaviour
     // Patrol: The enemy moves forward until raycast collision with a wall or a ledge. If collision with a wall/ledge, pause, turn around, and continue.
     private void Patrol()
     {
+		
+		// Animator: trying to define on spawn a walking animation starts. It currently does not work. 
+		anim.SetBool("isWalking", true);
+		anim.SetBool("isRunning", false);
+		anim.SetBool("isIdle", false);
+
 		if (hitPlayer())
 		{
 			currentState = "Rush";
@@ -191,12 +197,20 @@ public class EnemyControl : MonoBehaviour
 		if (hitWall() || hitObject() || hitLedge())
 		{
 		    Debug.Log("Hit wall/object!");
+
+			anim.SetBool("isWalking", false); // stop the walking animation for the turn, resume it after.
+			anim.SetBool("isIdle", true);
+
 		    patrolDirection *= -1;
 		    StartCoroutine(WaitToTurn(1f));
+
+			anim.SetBool("isIdle", false); // these and the ones above it don't seem to work for turning.
+			anim.SetBool("isWalking", true);
 		}
 		else
 		{
 		    rb.velocity = new Vector2(patrolSpeed * patrolDirection, rb.velocity.y);
+
 		}
 	}
 
@@ -242,6 +256,10 @@ public class EnemyControl : MonoBehaviour
 
 		Debug.Log("Time: " + attackTimer);
 
+		// while attacking, the brute should sprint.
+		anim.SetBool("isWalking", false);
+		anim.SetBool("isRunning", true);
+
 		if ((!hitObject() || !hitWall() || !hitLedge()) && attackTimer > 0)
 		{
 			float playerDirection = GameObject.Find("Player").transform.position.x - transform.position.x;
@@ -268,6 +286,8 @@ public class EnemyControl : MonoBehaviour
 
 			// TODO: Enable hurtbox here
 			// TODO: Trigger attack animation here
+				// unsure if this is actually where it should go. it works a little wonky.
+			anim.SetTrigger("isAttacking");
 		}
 		else
 		{
@@ -275,6 +295,7 @@ public class EnemyControl : MonoBehaviour
 			attackTimer = attackDuration;
 			// TODO: Disable Hurtbox here
 			// TODO: Disable animation here
+				// attacking is a trigger, don't need to disable it.
 			//Debug.Log("Moving to " + currentState + "state.");
 		}
 	}
@@ -295,6 +316,7 @@ public class EnemyControl : MonoBehaviour
 		Vector3 boxcastOrigin = boxCollider.bounds.center + new Vector3(patrolDirection * (beginAttackSize.x / 2 + beginAttackOffset.x), beginAttackOffset.y, 0);
 
 		RaycastHit2D hitPlayer = Physics2D.BoxCast(boxcastOrigin, beginAttackSize, 0, new Vector2(patrolDirection, 0), 0, LayerMask.GetMask("Player"));
+		anim.SetTrigger("isAttacking");
 
 		if (hitPlayer.collider != null)
 		{
@@ -348,6 +370,10 @@ public class EnemyControl : MonoBehaviour
 			if ((hitWall.collider == null || hitWall.distance > hitPlayer.distance) && (hitObject.collider == null || hitObject.distance > hitPlayer.distance))
 			{
 				Debug.Log("Player detected!");
+
+				anim.SetBool("isRunning", true);
+				anim.SetBool("isWalking", false);
+
 				return true;
 			}
 		}


### PR DESCRIPTION
Throughout the enemyControl document there are animation calls. Current problems:
1. The attack animation triggers 3x for some reason, probably has to do with the size of the boxcast keeping the trigger active for longer than necessary
2. On spawn the Charger will ALWAYS idle until it gets put into the tracking state. The code isn't commented so I don't know when the actual initialization is. I've commented where I've put attempted solutions.